### PR TITLE
Feat/festival

### DIFF
--- a/src/main/java/UniFest/domain/festival/controller/FestivalController.java
+++ b/src/main/java/UniFest/domain/festival/controller/FestivalController.java
@@ -1,0 +1,62 @@
+package UniFest.domain.festival.controller;
+
+import UniFest.domain.festival.service.FestivalService;
+import UniFest.dto.response.Response;
+import UniFest.dto.response.festival.FestivalSearchResponse;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/festival")
+public class FestivalController {
+
+    private final FestivalService festivalService;
+
+    //학교명 검색
+    @GetMapping("")
+    public Response<List<FestivalSearchResponse>> getFestivalByName(@RequestParam("name") String schoolName) {
+        log.debug("[FestivalController.getFestivalByName]");
+
+        return Response.ofSuccess("OK",festivalService.getFestivalByName(schoolName));
+    }
+
+    //전체 검색
+    @GetMapping("/all")
+    public Response<List<FestivalSearchResponse>> getAllFestival() {
+        log.debug("[FestivalController.getAllFestival]");
+
+        return Response.ofSuccess("OK", festivalService.getAllFestival());
+    }
+
+    //지역별 검색
+    @GetMapping("/region")
+    public Response<List<FestivalSearchResponse>> getFestivalByRegion(@RequestParam("region") String region) {
+        log.debug("[FestivalController.getFestivalByRegion]");
+
+        return Response.ofSuccess("OK", festivalService.getFestivalByRegion(region));
+    }
+
+    //다가오는 축제일정
+    @GetMapping("/after")
+    public Response<List<FestivalSearchResponse>> getAfterFestival() {
+        log.debug("[FestivalController.getAfterFestival]");
+
+        return Response.ofSuccess("OK", festivalService.getAfterFestival());
+    }
+
+    //오늘의 축제일정
+    @GetMapping("/today")
+    public Response<List<FestivalSearchResponse>> getFestivalByDate(@RequestParam("date") LocalDate date) {
+        log.debug("[FestivalController.getFestivalByDate]");
+
+        return Response.ofSuccess("OK", festivalService.getFestivalByDate(date));
+    }
+}

--- a/src/main/java/UniFest/domain/festival/entity/Festival.java
+++ b/src/main/java/UniFest/domain/festival/entity/Festival.java
@@ -4,6 +4,7 @@ import UniFest.domain.audit.BaseEntity;
 import UniFest.domain.school.entity.School;
 import UniFest.domain.star.entity.Enroll;
 import jakarta.persistence.*;
+import java.time.LocalDate;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -34,9 +35,9 @@ public class Festival extends BaseEntity {
     @OneToMany(mappedBy = "festival")
     private List<Enroll> enrollList = new ArrayList<>();
 
-    private LocalDateTime beginDate;
+    private LocalDate beginDate;
 
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     public void setSchool(School school){
         this.school = school;

--- a/src/main/java/UniFest/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/UniFest/domain/festival/repository/FestivalRepository.java
@@ -1,0 +1,48 @@
+package UniFest.domain.festival.repository;
+
+import UniFest.domain.festival.entity.Festival;
+import UniFest.dto.response.festival.FestivalSearchResponse;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FestivalRepository extends JpaRepository<Festival, Long> {
+
+    //학교
+    @Query("select new UniFest.dto.response.festival.FestivalSearchResponse(s.thumbnail, s.name, f.name, f.beginDate, f.endDate, s.latitude, s.longitude)"
+            + " from School s join Festival f on f.school.id=s.id"
+            + " where s.name like :schoolName"
+            + " order by s.name")
+    List<FestivalSearchResponse> findFestivalBySchool(@Param("schoolName") String schoolName);
+
+    //전체
+    @Query("select new UniFest.dto.response.festival.FestivalSearchResponse(s.thumbnail, s.name, f.name, f.beginDate, f.endDate, s.latitude, s.longitude)"
+            + " from School s join Festival f on f.school.id=s.id"
+            + " order by s.name")
+    List<FestivalSearchResponse> findAllFestival();
+
+    //지역
+    @Query("select new UniFest.dto.response.festival.FestivalSearchResponse(s.thumbnail, s.name, f.name, f.beginDate, f.endDate, s.latitude, s.longitude)"
+            + " from School s join Festival f on f.school.id=s.id"
+            + " where s.region = :region"
+            + " order by s.name")
+    List<FestivalSearchResponse> findFestivalByRegion(@Param("region") String region);
+
+    //다가오는
+    @Query("select new UniFest.dto.response.festival.FestivalSearchResponse(s.thumbnail, s.name, f.name, f.beginDate, f.endDate, s.latitude, s.longitude)"
+            + " from School s join Festival f on f.school.id=s.id"
+            + " where f.beginDate > CURRENT_DATE"
+            + " order by f.endDate")
+    List<FestivalSearchResponse> findAfterFestival(Pageable pageable);
+
+
+    //오늘
+    @Query("select new UniFest.dto.response.festival.FestivalSearchResponse(s.thumbnail, s.name, f.name, f.beginDate, f.endDate, s.latitude, s.longitude)"
+            + " from School s join Festival f on f.school.id=s.id"
+            + " where :date between f.beginDate and f.endDate "
+            + " order by s.name")
+    List<FestivalSearchResponse> findFestivalByDate(@Param("date") LocalDate date);
+}

--- a/src/main/java/UniFest/domain/festival/service/FestivalService.java
+++ b/src/main/java/UniFest/domain/festival/service/FestivalService.java
@@ -1,0 +1,57 @@
+package UniFest.domain.festival.service;
+
+import UniFest.domain.festival.repository.FestivalRepository;
+import UniFest.dto.response.festival.FestivalSearchResponse;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class FestivalService {
+
+    private final FestivalRepository festivalRepository;
+
+    //학교명 검색
+    public List<FestivalSearchResponse> getFestivalByName(String schoolName) {
+        log.debug("[FestivalService.getFestivalByName]");
+
+        schoolName = "%" + schoolName + "%";
+        return festivalRepository.findFestivalBySchool(schoolName);
+    }
+
+    //전체 검색
+    public List<FestivalSearchResponse> getAllFestival() {
+        log.debug("[FestivalService.getAllFestival]");
+
+        return festivalRepository.findAllFestival();
+    }
+
+    //지역별 검색
+    public List<FestivalSearchResponse> getFestivalByRegion(String region) {
+        log.debug("[FestivalService.getFestivalByRegion]");
+
+        return festivalRepository.findFestivalByRegion(region);
+    }
+
+    //다가오는 축제일정
+    public List<FestivalSearchResponse> getAfterFestival() {
+        log.debug("[FestivalService.getAfterFestival]");
+
+        return festivalRepository.findAfterFestival(PageRequest.of(0,5));
+    }
+
+    //오늘의 축제일정
+    public List<FestivalSearchResponse> getFestivalByDate(LocalDate date) {
+        log.debug("[FestivalService.getFestivalByDate]");
+
+        return festivalRepository.findFestivalByDate(date);
+    }
+
+}

--- a/src/main/java/UniFest/domain/school/entity/School.java
+++ b/src/main/java/UniFest/domain/school/entity/School.java
@@ -27,7 +27,7 @@ public class School extends BaseEntity {
 
     private float latitude;
 
-    private float longtitude;
+    private float longitude;
 
     @OneToMany(mappedBy = "school", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Festival> festivalList = new ArrayList<>();

--- a/src/main/java/UniFest/dto/response/festival/FestivalSearchResponse.java
+++ b/src/main/java/UniFest/dto/response/festival/FestivalSearchResponse.java
@@ -1,0 +1,23 @@
+package UniFest.dto.response.festival;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FestivalSearchResponse {
+
+    //학교로고
+    private String thumbnail;
+    //학교명
+    private String schoolName;
+    //축제명
+    private String festivalName;
+    //축제기간
+    private LocalDate beginDate;
+    private LocalDate endDate;
+    //위치
+    private float latitude;
+    private float longitude;
+}


### PR DESCRIPTION
## 개요
- 축제 조회 API 개발

## 작업사항
- School 도메인 필드명 수정. longtitude -> longitude
- Festival 도메인 필드타입 수정. 시작/종료일 LocalDateTime -> LocalDate
- 축제 조회 API 개발
    - 전체 조회
    - 학교명 검색 조회
    - 지역별 학교 축제 조회
    - 다가오는 축제 조회 - 종료일이 빠른 기준으로 5개
    - 오늘의 축제 조회 - 캘린더 상에서 선택한 날짜에 진행 중인 축제
## 주의사항
- rds 필드명 수정 완료. 개인 환경에서 수정 후 개발 진행 바랍니다.
- rds 필드타입 DATETIME -> DATE 수정 완료. 개인 환경에서 수정 후 개발 진행 바랍니다.
- 모든 검색 대상이 축제이므로 School 도메인에서 개발 진행하지 않았습니다.