### PR TITLE
fix : 축제 조회 응답Dto 필드 추가

### DIFF
--- a/src/main/java/UniFest/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/UniFest/domain/festival/repository/FestivalRepository.java
@@ -41,7 +41,7 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
 
 
     //오늘
-    @Query("select new UniFest.dto.response.festival.TodayFestivalInfo(s.id, s.name, f.id, f.name, :date)"
+    @Query("select new UniFest.dto.response.festival.TodayFestivalInfo(s.id, s.name, s.thumbnail, f.id, f.name, :date)"
             + " from School s join Festival f on f.school.id=s.id"
             + " where :date between f.beginDate and f.endDate "
             + " order by s.name")

--- a/src/main/java/UniFest/dto/response/festival/TodayFestivalInfo.java
+++ b/src/main/java/UniFest/dto/response/festival/TodayFestivalInfo.java
@@ -11,6 +11,7 @@ public class TodayFestivalInfo {
     private Long schoolId;
     //학교명
     private String schoolName;
+    private String thumbnail;
     //축제명
     private Long festivalId;
     private String festivalName;
@@ -18,10 +19,11 @@ public class TodayFestivalInfo {
     //연예인 정보
     private List<StarInfo> starList;
 
-    public TodayFestivalInfo(Long schoolId, String schoolName, Long festivalId, String festivalName,
+    public TodayFestivalInfo(Long schoolId, String schoolName, String thumbnail, Long festivalId, String festivalName,
             LocalDate date) {
         this.schoolId = schoolId;
         this.schoolName = schoolName;
+        this.thumbnail = thumbnail;
         this.festivalId = festivalId;
         this.festivalName = festivalName;
         this.date = date;


### PR DESCRIPTION
## 개요
- 현재 관심 축제 등록 시점에 오늘의 축제의 데이터를 사용한다.
해당 데이터에 학교 이미지가 존재하지 않아 관심 축제 등록 후 조회 시 default image 사용되는 문제 발생

## 작업사항
- 따라서 오늘의 축제 조회 응답 Dto에 thumbnail 필드 추가

## 주의사항
- 
- 
- 
