### PR TITLE
Fix/festival - 오늘의 축제 응답 필드 수정, 이미지 관련 필드명 수정

### DIFF
--- a/src/main/java/UniFest/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/UniFest/domain/festival/repository/FestivalRepository.java
@@ -41,7 +41,7 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
 
 
     //오늘
-    @Query("select new UniFest.dto.response.festival.TodayFestivalInfo(s.id, s.name, s.thumbnail, f.id, f.name, :date)"
+    @Query("select new UniFest.dto.response.festival.TodayFestivalInfo(s.id, s.name, s.thumbnail, f.id, f.name, f.beginDate, f.endDate)"
             + " from School s join Festival f on f.school.id=s.id"
             + " where :date between f.beginDate and f.endDate "
             + " order by s.name")

--- a/src/main/java/UniFest/domain/festival/service/FestivalService.java
+++ b/src/main/java/UniFest/domain/festival/service/FestivalService.java
@@ -75,9 +75,8 @@ public class FestivalService {
         for(TodayFestivalInfo todayFestivalInfo : festivalInfo) {
             Long festivalId = todayFestivalInfo.getFestivalId();
             for (EnrollInfo enrollInfo : starList) {
-                if (enrollInfo.getFestivalId().equals(todayFestivalInfo.getFestivalId())) {
-                    todayFestivalInfo.getStarList().add(new StarInfo(enrollInfo.getStarName(),
-                            enrollInfo.getStarImg()));
+                if (enrollInfo.getFestivalId().equals(festivalId)) {
+                    todayFestivalInfo.getStarList().add(new StarInfo(enrollInfo.getStarName(), enrollInfo.getImgUrl()));
                 }
             }
         }

--- a/src/main/java/UniFest/domain/star/controller/StarController.java
+++ b/src/main/java/UniFest/domain/star/controller/StarController.java
@@ -24,7 +24,7 @@ public class StarController {
         log.debug("[StarController.createStar]");
         Star star = new Star(
                 request.getName(),
-                request.getImg()
+                request.getImgUrl()
         );
 
         return Response.ofCreated("Created", starRepository.save(star).getId());

--- a/src/main/java/UniFest/dto/response/festival/TodayFestivalInfo.java
+++ b/src/main/java/UniFest/dto/response/festival/TodayFestivalInfo.java
@@ -15,18 +15,20 @@ public class TodayFestivalInfo {
     //축제명
     private Long festivalId;
     private String festivalName;
-    private LocalDate date;
+    private LocalDate beginDate;
+    private LocalDate endDate;
     //연예인 정보
     private List<StarInfo> starList;
 
     public TodayFestivalInfo(Long schoolId, String schoolName, String thumbnail, Long festivalId, String festivalName,
-            LocalDate date) {
+            LocalDate beginDate, LocalDate endDate) {
         this.schoolId = schoolId;
         this.schoolName = schoolName;
         this.thumbnail = thumbnail;
         this.festivalId = festivalId;
         this.festivalName = festivalName;
-        this.date = date;
+        this.beginDate = beginDate;
+        this.endDate = endDate;
         this.starList = new ArrayList<>();
     }
 }

--- a/src/main/java/UniFest/dto/response/star/EnrollInfo.java
+++ b/src/main/java/UniFest/dto/response/star/EnrollInfo.java
@@ -9,5 +9,5 @@ public class EnrollInfo {
 
     private Long festivalId;
     private String starName;
-    private String starImg;
+    private String imgUrl;
 }

--- a/src/main/java/UniFest/dto/response/star/StarInfo.java
+++ b/src/main/java/UniFest/dto/response/star/StarInfo.java
@@ -8,5 +8,5 @@ import lombok.Getter;
 public class StarInfo {
 
     private String name;
-    private String img;
+    private String imgUrl;
 }


### PR DESCRIPTION
## 개요
- 관심 축제 등록 과정에서 관심 축제 등록을 시도하는 화면에 따라 다르게 정보가 저장되는 버그 수정
    -> 응답 데이터에 당일 날짜를 포함하는 것이 아닌 축제 시작/종료일 포함하는 것으로 수정
- EnrollInfo, StarInfo 필드명 수정

## 작업사항
- TodayFestivalInfo
    - date -> beginDate, endDate
- EnrollInfo, StarInfo
    - imgUrl
    
## 주의사항
- 
- 
- 
