### PR TITLE
fix : festival/today 응답 Dto 수정

### DIFF
--- a/src/main/java/UniFest/domain/festival/service/FestivalService.java
+++ b/src/main/java/UniFest/domain/festival/service/FestivalService.java
@@ -68,7 +68,7 @@ public class FestivalService {
 
         //축제명, 학교명, 축제id, 당일날짜
         List<TodayFestivalInfo> festivalInfo = festivalRepository.findFestivalByDate(date);
-        //축제id, 연예인이름 사진
+        //축제id, 연예인id, 연예인이름, 사진
         List<EnrollInfo> starList = enrollRepository.findByDate(date);
 
         //TODO 성능개선
@@ -76,7 +76,7 @@ public class FestivalService {
             Long festivalId = todayFestivalInfo.getFestivalId();
             for (EnrollInfo enrollInfo : starList) {
                 if (enrollInfo.getFestivalId().equals(festivalId)) {
-                    todayFestivalInfo.getStarList().add(new StarInfo(enrollInfo.getStarName(), enrollInfo.getImgUrl()));
+                    todayFestivalInfo.getStarList().add(new StarInfo(enrollInfo.getStarId(), enrollInfo.getStarName(), enrollInfo.getImgUrl()));
                 }
             }
         }

--- a/src/main/java/UniFest/domain/star/repository/EnrollRepository.java
+++ b/src/main/java/UniFest/domain/star/repository/EnrollRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface EnrollRepository extends JpaRepository<Enroll, Long> {
 
-    @Query("select new UniFest.dto.response.star.EnrollInfo(e.festival.id, s.name, s.img) from Enroll e"
+    @Query("select new UniFest.dto.response.star.EnrollInfo(e.festival.id, s.id, s.name, s.img) from Enroll e"
             + " join Star s on e.star.id=s.id"
             + " where e.visitDate=:date")
     List<EnrollInfo> findByDate(@Param("date") LocalDate date);

--- a/src/main/java/UniFest/dto/response/star/EnrollInfo.java
+++ b/src/main/java/UniFest/dto/response/star/EnrollInfo.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class EnrollInfo {
 
     private Long festivalId;
+    private Long starId;
     private String starName;
     private String imgUrl;
 }

--- a/src/main/java/UniFest/dto/response/star/StarInfo.java
+++ b/src/main/java/UniFest/dto/response/star/StarInfo.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public class StarInfo {
 
+    private Long starId;
     private String name;
     private String imgUrl;
 }


### PR DESCRIPTION
## 개요
- 프론트엔드 측의 중복선택 이슈. 로컬에서 연예인 Id를 고유하게 사용하기 위해 수정하였음

## 작업사항
- EnrollInfo
    - Long starId 필드 추가
- starInfo
    - Long starId 필드 추가
- EnrollRepository
    - findByDate 메서드에서 조회 값(starId) 추가
- FestivalService
    - 최종 응답 Dto 내부에 starId 추가

## 주의사항
- 
- 
- 
