### PR TITLE
feat : 멤버 역할변경 api 개발

### DIFF
--- a/src/main/java/UniFest/config/SecurityConfig.java
+++ b/src/main/java/UniFest/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig{
         //경로별 인가작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/admin").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH,"/members").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/booths").permitAll()
                         .requestMatchers("/api/booths").hasAnyRole("ADMIN","VERIFIED")
                         //TODO 상위 5개 부스 조회 시 VERIFIED여도 막힘

--- a/src/main/java/UniFest/config/SecurityConfig.java
+++ b/src/main/java/UniFest/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig{
         //경로별 인가작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers(HttpMethod.PATCH,"/members").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH,"/members/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/booths").permitAll()
                         .requestMatchers("/api/booths").hasAnyRole("ADMIN","VERIFIED")
                         //TODO 상위 5개 부스 조회 시 VERIFIED여도 막힘

--- a/src/main/java/UniFest/domain/booth/service/BoothService.java
+++ b/src/main/java/UniFest/domain/booth/service/BoothService.java
@@ -60,7 +60,6 @@ public class BoothService {
     //value::key의 형태로 redis key 생성
     @Cacheable(value = "BoothInfo", key = "#boothId",cacheManager = "redisCacheManager")
     public BoothDetailResponse getBooth(Long boothId) {
-        log.info("[특정 부스 조회]");
         Booth findBooth = boothRepository.findByBoothId(boothId)
                 .filter(b -> b.isEnabled())
                 .orElseThrow(BoothNotFoundException::new);

--- a/src/main/java/UniFest/domain/member/controller/MemberController.java
+++ b/src/main/java/UniFest/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package UniFest.domain.member.controller;
 
+import UniFest.domain.member.entity.MemberRole;
 import UniFest.domain.member.service.MemberService;
 import UniFest.dto.request.member.MemberSignUpRequest;
 import UniFest.dto.response.Response;
@@ -24,6 +25,14 @@ public class MemberController {
     public Response postMember(@Valid @RequestBody MemberSignUpRequest memberSignUpRequest) {
         Long savedId = memberService.createMember(memberSignUpRequest);
         return Response.ofSuccess("OK",savedId);
+    }
+    @SecurityRequirement(name = "JWT")
+    @Operation(summary = "회원역할변경")
+    @PatchMapping("/{member-id}")
+    public Response patchMemberRole(@PathVariable("member-id") Long memberId,
+                                    @RequestParam("role")MemberRole memberRole) {
+        Long updatedId = memberService.updateMemberRole(memberId,memberRole);
+        return Response.ofSuccess("OK",updatedId);
     }
 
     @SecurityRequirement(name = "JWT")

--- a/src/main/java/UniFest/domain/member/service/MemberService.java
+++ b/src/main/java/UniFest/domain/member/service/MemberService.java
@@ -54,7 +54,7 @@ public class MemberService {
             throw new MemberEmailExistException();
         }
     }
-
+    @Transactional
     public Long updateMemberRole(Long memberId, MemberRole memberRole) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         if(member.getMemberRole() == MemberRole.ADMIN) throw new RuntimeException("ADMIN의 역할 변경은 불가합니다.");

--- a/src/main/java/UniFest/domain/member/service/MemberService.java
+++ b/src/main/java/UniFest/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import UniFest.dto.request.member.MemberSignUpRequest;
 import UniFest.dto.response.member.MemberDetailResponse;
 import UniFest.exception.member.MemberEmailExistException;
 import UniFest.exception.member.MemberNotFoundException;
+import UniFest.security.userdetails.MemberDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -52,5 +53,12 @@ public class MemberService {
         if (memberRepository.existsByEmail(email)) {
             throw new MemberEmailExistException();
         }
+    }
+
+    public Long updateMemberRole(Long memberId, MemberRole memberRole) {
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        if(member.getMemberRole() == MemberRole.ADMIN) throw new RuntimeException("ADMIN의 역할 변경은 불가합니다.");
+        member.updateRole(memberRole);
+        return member.getId();
     }
 }

--- a/src/main/java/UniFest/dto/response/booth/BoothDetailResponse.java
+++ b/src/main/java/UniFest/dto/response/booth/BoothDetailResponse.java
@@ -35,7 +35,6 @@ public class BoothDetailResponse {
 
     private List<MenuResponse> menus;
 
-    private int likes;
 
     public BoothDetailResponse(Booth booth){
         this.id = booth.getId();
@@ -48,7 +47,6 @@ public class BoothDetailResponse {
         this.latitude = booth.getLatitude();
         this.longitude = booth.getLongitude();
         this.menus = booth.getMenuList().stream().map(MenuResponse::new).collect(Collectors.toList());
-        this.likes = booth.getLikesCount();
     }
 
 }


### PR DESCRIPTION
## 개요
- 멤버 역할변경 api 개발
- security 권한설정
- BoothDetailResponse에서 좋아요 수 삭제

## 작업사항
- 역할변경 api 생성과, 좋아요 수 반환 api 따로 만들었기 떄문에 부스상세조회에서 좋아요수 항목을 삭제했습니다

## 주의사항
