### PR TITLE
fix : 업로드 이미지 용량 수정 및 예외처리

### DIFF
--- a/src/main/java/UniFest/exception/file/UploadSizeExceedException.java
+++ b/src/main/java/UniFest/exception/file/UploadSizeExceedException.java
@@ -1,0 +1,11 @@
+package UniFest.exception.file;
+
+import UniFest.exception.UnifestCustomException;
+import org.springframework.http.HttpStatus;
+
+public class UploadSizeExceedException extends UnifestCustomException {
+
+    public UploadSizeExceedException() {
+        super(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 이미지 용량을 초과하였습니다.", 3001);
+    }
+}

--- a/src/main/java/UniFest/fileupload/utils/S3ImageUploader.java
+++ b/src/main/java/UniFest/fileupload/utils/S3ImageUploader.java
@@ -2,6 +2,7 @@ package UniFest.fileupload.utils;
 
 import UniFest.dto.response.file.FileResponse;
 import UniFest.exception.file.ImageConvertingFailedException;
+import UniFest.exception.file.UploadSizeExceedException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -22,12 +23,19 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class S3ImageUploader {
 
+    private static final long MAX_IMAGE_SIZE = 3 * 1024 * 1024;
+
     private final AmazonS3Client amazonS3Client;
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
     // MultipartFile을 전달받아 File로 전환한 후 S3에 업로드
     public FileResponse uploadImage(MultipartFile file, String extension) throws IOException {
+
+        if (file.getSize() > MAX_IMAGE_SIZE) {
+            throw new UploadSizeExceedException();
+        }
+
         File convertedFile = convertFile(file).orElseThrow(ImageConvertingFailedException::new);
         //extension 확장자명 filename -> 저장용파일명
         String fileName = UUID.randomUUID() + "." + extension;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,9 @@ spring:
     url: ${DATASOURCE_URL}
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD}
-
+  servlet:
+    multipart:
+      max-file-size: 3MB
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 개요
- 이미지 업로드 가능한 용량 수정

## 작업사항
- application.yml
    - max-file-size : 3MB
- UploadSizeExceedException 클래스 생성
- S3ImageUploader.uploadImage 메서드에서 용량 초과 시 예외처리

## 주의사항
- 
- 
- 
