### PR TITLE
fix : 메뉴 등록/삭제 시 부스정보 캐싱데이터 삭제

### DIFF
--- a/src/main/java/UniFest/config/CacheConfig.java
+++ b/src/main/java/UniFest/config/CacheConfig.java
@@ -25,7 +25,7 @@ public class CacheConfig {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofMinutes(10L)); // 캐시 수명 100분
+                .entryTtl(Duration.ofMinutes(100L)); // 캐시 수명 100분
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(redisConnectionFactory)
                 .cacheDefaults(redisCacheConfiguration).build();

--- a/src/main/java/UniFest/domain/member/service/MemberService.java
+++ b/src/main/java/UniFest/domain/member/service/MemberService.java
@@ -46,7 +46,7 @@ public class MemberService {
                 .password(encryptedPassword)
                 .school(school)
                 .phoneNum(request.getPhoneNum())
-                .memberRole(MemberRole.PENDING)
+                .memberRole(MemberRole.VERIFIED)
                 .build();
 
         return memberRepository.save(member).getId();

--- a/src/main/java/UniFest/domain/menu/controller/MenuController.java
+++ b/src/main/java/UniFest/domain/menu/controller/MenuController.java
@@ -33,7 +33,7 @@ public class MenuController {
     @SecurityRequirement(name = "JWT")
     @Operation(summary = "메뉴 삭제")
     @DeleteMapping("{menu-id}")
-    public Response postMenu(@PathVariable("menu-id") Long menuId,
+    public Response deleteMenu(@PathVariable("menu-id") Long menuId,
                              @AuthenticationPrincipal MemberDetails memberDetails) {
         menuService.deleteMenu(menuId, memberDetails);
         return Response.ofSuccess("OK",null);

--- a/src/main/java/UniFest/domain/menu/service/MenuService.java
+++ b/src/main/java/UniFest/domain/menu/service/MenuService.java
@@ -10,6 +10,9 @@ import UniFest.exception.member.MemberEmailExistException;
 import UniFest.exception.menu.MenuNotFoundException;
 import UniFest.security.userdetails.MemberDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,27 +26,36 @@ public class MenuService {
 
     private final BoothRepository boothRepository;
     private final MenuRepository menuRepository;
+    private final CacheManager cacheManager;
+
+
+    @CacheEvict(value = "BoothInfo", key = "#boothId")
     public Long postMenu(MenuCreateRequest menuCreateRequest, Long boothId, MemberDetails memberDetails) {
-        Booth booth = boothRepository.findById(boothId).orElseThrow(BoothNotFoundException::new);
-        checkBoothAuth(booth, memberDetails);
+        Booth findbooth = boothRepository.findById(boothId).orElseThrow(BoothNotFoundException::new);
+        checkBoothAuth(findbooth, memberDetails);
         Menu menu = Menu.builder()
                 .name(menuCreateRequest.getName())
                 .price(menuCreateRequest.getPrice())
                 .imgUrl(menuCreateRequest.getImgUrl())
                 .build();
-        menu.setBooth(booth);
+        menu.setBooth(findbooth);
 
         return menuRepository.save(menu).getId();
     }
+
+    public void deleteMenu(Long menuId, MemberDetails memberDetails) {
+        Menu findMenu = menuRepository.findById(menuId).orElseThrow(MenuNotFoundException::new);
+        Booth findbooth = findMenu.getBooth();
+        cacheManager.getCache("BoothInfo").evict(findbooth.getId());
+        checkBoothAuth(findbooth, memberDetails);
+        menuRepository.delete(findMenu);
+    }
+
 
     public void checkBoothAuth(Booth booth, MemberDetails memberDetails){
         if(!booth.getMember().getEmail().equals(memberDetails.getEmail())){
             throw new RuntimeException("권한이 없습니다.");
         }
     }
-    public void deleteMenu(Long menuId, MemberDetails memberDetails) {
-        Menu findMenu = menuRepository.findById(menuId).orElseThrow(MenuNotFoundException::new);
-        checkBoothAuth(findMenu.getBooth(), memberDetails);
-        menuRepository.delete(findMenu);
-    }
+
 }


### PR DESCRIPTION
## 개요
- fix : 메뉴 등록/삭제 시 부스정보 캐싱데이터 삭제

## 작업사항
- fix : 메뉴 등록/삭제 시 부스정보 캐싱데이터 삭제
- 멤버 가입시 디폴트 역할 verified 설정

## 주의사항
- 
- 
- 
