### PR TITLE
Feat/boothschedule

### DIFF
--- a/src/main/java/UniFest/config/CacheConfig.java
+++ b/src/main/java/UniFest/config/CacheConfig.java
@@ -25,7 +25,7 @@ public class CacheConfig {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofMinutes(100L)); // 캐시 수명 100분
+                .entryTtl(Duration.ofMinutes(600L));
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(redisConnectionFactory)
                 .cacheDefaults(redisCacheConfiguration).build();

--- a/src/main/java/UniFest/domain/booth/entity/Booth.java
+++ b/src/main/java/UniFest/domain/booth/entity/Booth.java
@@ -68,6 +68,9 @@ public class Booth extends BaseEntity {
     @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Waiting> waitingList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BoothSchedule> scheduleList = new ArrayList<>();
+
     private String location;
 
     private double latitude;

--- a/src/main/java/UniFest/domain/booth/entity/BoothSchedule.java
+++ b/src/main/java/UniFest/domain/booth/entity/BoothSchedule.java
@@ -1,0 +1,37 @@
+package UniFest.domain.booth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(name = "booth_schedule")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoothSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="booth_schedule_id")
+    private Long id;
+
+    private LocalDate openDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_id")
+    private Booth booth;
+    @Builder
+    public BoothSchedule(LocalDate openDate){
+        this.openDate = openDate;
+    }
+
+    public void setBooth(Booth booth){
+        this.booth = booth;
+        booth.getScheduleList().add(this);
+    }
+
+}

--- a/src/main/java/UniFest/domain/booth/repository/BoothRepository.java
+++ b/src/main/java/UniFest/domain/booth/repository/BoothRepository.java
@@ -3,10 +3,13 @@ package UniFest.domain.booth.repository;
 import UniFest.domain.booth.entity.Booth;
 import UniFest.domain.festival.entity.Festival;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 @Repository
@@ -22,4 +25,12 @@ public interface BoothRepository extends JpaRepository<Booth,Long> {
     Optional<Booth> findByBoothId(@Param("boothId") Long boothId);
     List<Booth> findAllByFestivalAndEnabled(Festival festival, boolean enabled);
     List<Booth> findBoothsByIdIn(List<Long> boothIds);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Booth b SET b.enabled = :isEnabled WHERE EXISTS (SELECT s FROM b.scheduleList s WHERE FUNCTION('date', s.openDate) = :today)")
+    void updateBoothEnabled(LocalDate today, boolean isEnabled);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Booth b SET b.enabled = :isEnabled WHERE NOT EXISTS (SELECT s FROM b.scheduleList s WHERE FUNCTION('date', s.openDate) = :today)")
+    void updateBoothDisabled(LocalDate today, boolean isEnabled);
 }

--- a/src/main/java/UniFest/domain/booth/repository/BoothScheduleRepository.java
+++ b/src/main/java/UniFest/domain/booth/repository/BoothScheduleRepository.java
@@ -1,0 +1,9 @@
+package UniFest.domain.booth.repository;
+
+import UniFest.domain.booth.entity.BoothSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoothScheduleRepository extends JpaRepository<BoothSchedule,Long> {
+}

--- a/src/main/java/UniFest/domain/booth/repository/BoothScheduleRepository.java
+++ b/src/main/java/UniFest/domain/booth/repository/BoothScheduleRepository.java
@@ -2,8 +2,16 @@ package UniFest.domain.booth.repository;
 
 import UniFest.domain.booth.entity.BoothSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
 
 @Repository
 public interface BoothScheduleRepository extends JpaRepository<BoothSchedule,Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM BoothSchedule b where b.openDate <:today")
+    void deleteBoothSchedule(LocalDate today);
 }

--- a/src/main/java/UniFest/domain/booth/repository/BoothTagRelRepository.java
+++ b/src/main/java/UniFest/domain/booth/repository/BoothTagRelRepository.java
@@ -2,7 +2,9 @@ package UniFest.domain.booth.repository;
 
 import UniFest.domain.booth.entity.BoothTagRel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface BoothTagRelRepository extends JpaRepository<BoothTagRel,Long> {
 
 }

--- a/src/main/java/UniFest/domain/booth/service/BoothService.java
+++ b/src/main/java/UniFest/domain/booth/service/BoothService.java
@@ -148,6 +148,12 @@ public class BoothService {
         boothRepository.updateBoothDisabled(now, false);
     }
 
+    @Transactional
+    public void deleteBoothSchedule() {
+        LocalDate now = LocalDate.now();
+        boothScheduleRepository.deleteBoothSchedule(now);
+    }
+
     public Booth verifyAuth(Long memberId, Long boothId){
         Booth findBooth = boothRepository.findByBoothId(boothId)
                 .orElseThrow(BoothNotFoundException::new);

--- a/src/main/java/UniFest/domain/booth/service/BoothService.java
+++ b/src/main/java/UniFest/domain/booth/service/BoothService.java
@@ -58,6 +58,7 @@ public class BoothService {
                 .festival(festival)
                 .build();
         booth.setMember(member);
+
         LocalDate beginDate = festival.getBeginDate();
         LocalDate endDate = festival.getEndDate();
         for(Long turn : boothCreateRequest.getOpenDates()){

--- a/src/main/java/UniFest/domain/booth/utils/BoothEnabledScheduler.java
+++ b/src/main/java/UniFest/domain/booth/utils/BoothEnabledScheduler.java
@@ -13,11 +13,12 @@ public class BoothEnabledScheduler {
 
     private final BoothService boothService;
 
-    // 매일 새벽 3시 30분 : 금일 운영하지 않는 부스 disabled 처리
+    // 매일 새벽 3시 30분 : 금일 운영하지 않는 부스 disabled 처리, 운영하는 부스 enabled 처리
     @Scheduled(cron = "0 30 3 * * ?")
     public void updateMemberStatus() {
         boothService.updateBoothEnabled();
         boothService.updateBoothDisabled();
+        boothService.deleteBoothSchedule();
         log.info("booth-enabled updated successfully!");
     }
 }

--- a/src/main/java/UniFest/domain/booth/utils/BoothEnabledScheduler.java
+++ b/src/main/java/UniFest/domain/booth/utils/BoothEnabledScheduler.java
@@ -1,0 +1,23 @@
+package UniFest.domain.booth.utils;
+
+import UniFest.domain.booth.service.BoothService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class BoothEnabledScheduler {
+
+    private final BoothService boothService;
+
+    // 매일 새벽 3시 30분 : 금일 운영하지 않는 부스 disabled 처리
+    @Scheduled(cron = "0 30 3 * * ?")
+    public void updateMemberStatus() {
+        boothService.updateBoothEnabled();
+        boothService.updateBoothDisabled();
+        log.info("booth-enabled updated successfully!");
+    }
+}

--- a/src/main/java/UniFest/dto/request/booth/BoothCreateRequest.java
+++ b/src/main/java/UniFest/dto/request/booth/BoothCreateRequest.java
@@ -5,21 +5,30 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+
+import java.time.LocalDate;
+import java.util.List;
 
 
 @Data
 public class BoothCreateRequest {
 
     @NotBlank(message = "공백일 수 없습니다.")
+    @Length(min=2, max=30)
     private String name;
     @NotNull(message = "공백일 수 없습니다.")
     private BoothCategory category;
+    @Length(max=200)
     private String description;
     private String detail;
     private String thumbnail;
+    @Length(max=100)
     private String warning;
     private Long festivalId;
+    private List<Long> openDates;
     @NotNull(message = "공백일 수 없습니다.")
+    @Length(max=40)
     private String location;
     @NotNull(message = "공백일 수 없습니다.")
     private double latitude;

--- a/src/main/java/UniFest/dto/request/booth/BoothCreateRequest.java
+++ b/src/main/java/UniFest/dto/request/booth/BoothCreateRequest.java
@@ -1,6 +1,7 @@
 package UniFest.dto.request.booth;
 
 import UniFest.domain.booth.entity.BoothCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -26,6 +27,7 @@ public class BoothCreateRequest {
     @Length(max=100)
     private String warning;
     private Long festivalId;
+    @Schema(description = "부스 운영날짜", example = ": 첫째날 둘째날 셋째날 운영 시 : {1,2,3} ")
     private List<Long> openDates;
     @NotNull(message = "공백일 수 없습니다.")
     @Length(max=40)

--- a/src/main/java/UniFest/dto/request/menu/MenuCreateRequest.java
+++ b/src/main/java/UniFest/dto/request/menu/MenuCreateRequest.java
@@ -4,11 +4,13 @@ package UniFest.dto.request.menu;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.Length;
 
 @Data
 public class MenuCreateRequest {
 
     @NotBlank(message = "메뉴 이름을 입력해주세요.")
+    @Length(max=20)
     private String name;
 
     @NotNull(message = "메뉴 가격을 입력해주세요.")


### PR DESCRIPTION
## 개요
- booth_schedule 테이블 생성
- 부스 생성 시, 운영날짜 추가
- 운영날짜에 맞춰 부스 enabled 값 update 벌크연산
- 금일날짜에 맞춰 boothSchedule 테이블 delete 벌크연산 

## 작업사항
- 부스 운영날짜가 아닐 시 , 부스 enabled false 설정
- 부스 운영날짜일 시, 부스 enabled true 설정
-  booth_schedule 테이블의 opendate가 금일날짜보다 이전일 시 데이터 삭제
-  오전 3시 30분 운영날짜에 맞춰 모두 update, delete 실행


## 주의사항
- 
