### PR TITLE
feat : update Booth, Menu Response

### DIFF
--- a/src/main/java/UniFest/dto/response/booth/BoothDetailResponse.java
+++ b/src/main/java/UniFest/dto/response/booth/BoothDetailResponse.java
@@ -36,6 +36,8 @@ public class BoothDetailResponse {
 
     private boolean enabled;
 
+    private boolean waitingEnabled;
+
     public BoothDetailResponse(Booth booth){
         this.id = booth.getId();
         this.name = booth.getName();
@@ -48,6 +50,7 @@ public class BoothDetailResponse {
         this.longitude = booth.getLongitude();
         this.enabled = booth.isEnabled();
         this.menus = booth.getMenuList().stream().map(MenuResponse::new).collect(Collectors.toList());
+        this.waitingEnabled = booth.isWaitingEnabled();
     }
 
 }

--- a/src/main/java/UniFest/dto/response/booth/BoothResponse.java
+++ b/src/main/java/UniFest/dto/response/booth/BoothResponse.java
@@ -25,6 +25,8 @@ public class BoothResponse {
 
     private boolean enabled;
 
+    private boolean waitingEnabled;
+
     public BoothResponse(Booth booth){
         this.id = booth.getId();
         this.name = booth.getName();
@@ -35,5 +37,6 @@ public class BoothResponse {
         this.latitude = booth.getLatitude();
         this.longitude = booth.getLongitude();
         this.enabled = booth.isEnabled();
+        this.waitingEnabled = booth.isWaitingEnabled();
     }
 }

--- a/src/main/java/UniFest/dto/response/menu/MenuResponse.java
+++ b/src/main/java/UniFest/dto/response/menu/MenuResponse.java
@@ -1,6 +1,7 @@
 package UniFest.dto.response.menu;
 
 import UniFest.domain.menu.entity.Menu;
+import UniFest.domain.menu.entity.MenuStatus;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,10 +18,13 @@ public class MenuResponse {
 
     private String imgUrl;
 
+    private MenuStatus menuStatus;
+
     public MenuResponse(Menu menu){
         this.id = menu.getId();
         this.name = menu.getName();
         this.price = menu.getPrice();
         this.imgUrl = menu.getImgUrl();
+        this.menuStatus = menu.getMenuStatus();
     }
 }


### PR DESCRIPTION
프론트단의 요청에 맞추어 부스, 메뉴의 Response를 update 하였습니다.

변경사항
- Booth 관련 Response
>- waitingEnabled 필드 추가
>- 영향 API : GET /api/booths/{booth-id} 특정 부스 조회, GET /api/booths 상위 5개 부스 확인
- Menu 관련
>- menuStatus 필드 추가
>- 영향 API : GET /api/booths/{booth-id}
      * 부스 조회시 같이 불러와지는 Menu Entity