### PR TITLE
feat: add Booth/OpeningHour

### DIFF
--- a/src/main/java/UniFest/config/JacksonConfig.java
+++ b/src/main/java/UniFest/config/JacksonConfig.java
@@ -1,0 +1,19 @@
+package UniFest.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper registerObjectMapper(){
+        //Spring에 Object Mapper 등록
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+
+}

--- a/src/main/java/UniFest/domain/booth/entity/Booth.java
+++ b/src/main/java/UniFest/domain/booth/entity/Booth.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -86,9 +87,13 @@ public class Booth extends BaseEntity {
     //Waiting을 위한 Booth별 pin
     private String pin;
 
+    private LocalTime openTime;
+    private LocalTime closeTime;
+
     @Builder
     public Booth(String name, BoothCategory category, String description, String detail, String thumbnail,
-                 String warning, boolean enabled, String location, double latitude, double longitude, Festival festival, boolean waitingEnabled) {
+                 String warning, boolean enabled, String location, double latitude, double longitude, Festival festival, boolean waitingEnabled,
+                 LocalTime openTime, LocalTime closeTime) {
         this.name = name;
         this.category = category;
         this.description = description;
@@ -101,6 +106,8 @@ public class Booth extends BaseEntity {
         this.longitude = longitude;
         this.festival = festival;
         this.waitingEnabled = waitingEnabled;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
     }
     public int getLikesCount(){
         return this.likesList.size();
@@ -164,6 +171,9 @@ public class Booth extends BaseEntity {
         return this.pin;
     }
 
-
+    public void setOpeningHour(LocalTime openTime, LocalTime closeTime){
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+    }
 
 }

--- a/src/main/java/UniFest/dto/request/booth/BoothCreateRequest.java
+++ b/src/main/java/UniFest/dto/request/booth/BoothCreateRequest.java
@@ -2,14 +2,14 @@ package UniFest.dto.request.booth;
 
 import UniFest.domain.booth.entity.BoothCategory;
 import UniFest.dto.request.menu.MenuCreateRequest;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;
 
-import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 
@@ -38,5 +38,11 @@ public class BoothCreateRequest {
     private double latitude;
     @NotNull(message = "공백일 수 없습니다.")
     private double longitude;
+    @NotNull(message = "공백일 수 없습니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    private LocalTime openTime;
+    @NotNull(message = "공백일 수 없습니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    private LocalTime closeTime;
 
 }

--- a/src/main/java/UniFest/dto/request/booth/BoothPatchRequest.java
+++ b/src/main/java/UniFest/dto/request/booth/BoothPatchRequest.java
@@ -1,9 +1,10 @@
 package UniFest.dto.request.booth;
 
 import UniFest.domain.booth.entity.BoothCategory;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
+
+import java.time.LocalTime;
 
 
 @Data
@@ -19,5 +20,11 @@ public class BoothPatchRequest {
     private Boolean enabled;
     private Double latitude;
     private Double longitude;
+
+    private Boolean waitingEnabled;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    private LocalTime openTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    private LocalTime closeTime;
 
 }

--- a/src/main/java/UniFest/dto/response/booth/BoothDetailResponse.java
+++ b/src/main/java/UniFest/dto/response/booth/BoothDetailResponse.java
@@ -3,10 +3,12 @@ package UniFest.dto.response.booth;
 import UniFest.domain.booth.entity.Booth;
 import UniFest.domain.booth.entity.BoothCategory;
 import UniFest.dto.response.menu.MenuResponse;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,6 +40,11 @@ public class BoothDetailResponse {
 
     private boolean waitingEnabled;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING,pattern = "HH:mm:ss")
+    private LocalTime openTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING,pattern = "HH:mm:ss")
+    private LocalTime closeTime;
+
     public BoothDetailResponse(Booth booth){
         this.id = booth.getId();
         this.name = booth.getName();
@@ -51,6 +58,8 @@ public class BoothDetailResponse {
         this.enabled = booth.isEnabled();
         this.menus = booth.getMenuList().stream().map(MenuResponse::new).collect(Collectors.toList());
         this.waitingEnabled = booth.isWaitingEnabled();
+        this.openTime = booth.getOpenTime();
+        this.closeTime = booth.getCloseTime();
     }
 
 }

--- a/src/main/java/UniFest/dto/response/booth/BoothResponse.java
+++ b/src/main/java/UniFest/dto/response/booth/BoothResponse.java
@@ -3,6 +3,9 @@ package UniFest.dto.response.booth;
 import UniFest.domain.booth.entity.Booth;
 import UniFest.domain.booth.entity.BoothCategory;
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalTime;
 
 
 @Data
@@ -26,6 +29,12 @@ public class BoothResponse {
     private boolean enabled;
 
     private boolean waitingEnabled;
+
+    @DateTimeFormat(pattern = "HH:mm:ss")
+    private LocalTime openTime;
+
+    @DateTimeFormat(pattern = "HH:mm:ss")
+    private LocalTime closeTime;
 
     public BoothResponse(Booth booth){
         this.id = booth.getId();

--- a/src/main/java/UniFest/exception/booth/OpeningTimeNotCorrectException.java
+++ b/src/main/java/UniFest/exception/booth/OpeningTimeNotCorrectException.java
@@ -1,0 +1,11 @@
+package UniFest.exception.booth;
+
+import UniFest.exception.UnifestCustomException;
+import org.springframework.http.HttpStatus;
+
+public class OpeningTimeNotCorrectException extends UnifestCustomException {
+
+    public OpeningTimeNotCorrectException() {
+        super(HttpStatus.BAD_REQUEST, "폐점시간이 개점시간보다 빠릅니다.", 4001);
+    }
+}


### PR DESCRIPTION
변경사항
- CacheConfig 수정 : ObjectMapper Redis에 추가
- Booth, Booth 관련 Request/Response 운영시간(opening hour) 필드 추가 (개점/폐점)

추가사항
- OpeningTimeNotCorrectException 추가 : 폐점시간이 개점시간보다 빠를경우 BadRequest

요청/응답시 주의점
- Json Time Format이 아닌 HH:mm:ss format으로 보내게 의도