### PR TITLE
fix: correct addWaitingOrderByBooth

### DIFF
--- a/src/main/java/UniFest/domain/waiting/service/WaitingService.java
+++ b/src/main/java/UniFest/domain/waiting/service/WaitingService.java
@@ -47,17 +47,20 @@ public class WaitingService {
 
     private List<WaitingInfo> addWaitingOrderByBooth(List<Waiting> waitingList) {
         return waitingList.stream()
-                .filter(waiting -> "RESERVED".equals(waiting.getWaitingStatus()))  // RESERVED 상태만 필터링
                 .collect(Collectors.groupingBy(Waiting::getBooth))  // Booth별로 그룹화
                 .entrySet().stream()
                 .flatMap(entry -> {
                     AtomicInteger order = new AtomicInteger(1);
                     return entry.getValue().stream()
-                            .map(waiting -> createWaitingInfo(waiting, order.getAndIncrement()));
+                            .map(waiting -> {
+                                Integer waitingOrder = "RESERVED".equals(waiting.getWaitingStatus())
+                                        ? order.getAndIncrement()
+                                        : null;
+                                return createWaitingInfo(waiting, waitingOrder);
+                            });
                 })
                 .collect(Collectors.toList());
     }
-
     @Transactional
     public List<WaitingInfo> getMyWaitingList(String deviceId) {
         List<String> statuses = Arrays.asList("RESERVED", "CALLED", "NOSHOW");


### PR DESCRIPTION
- filter를 맨 처음에 걸어버리면 웨이팅 목록 획득에 오류 존재하므로 순서 부여때만 의미있도록 함