### PR TITLE
refactor: change FCM token API method to PUT and remove GET endpoint

### DIFF
--- a/src/main/java/UniFest/domain/fcm/controller/FcmController.java
+++ b/src/main/java/UniFest/domain/fcm/controller/FcmController.java
@@ -14,17 +14,17 @@ import org.springframework.web.bind.annotation.*;
 public class FcmController {
     private final FcmService syncService;
 
-    @PostMapping
+    @PutMapping
     public Response<String> saveOrUpdateFcmToken(@RequestBody PostFcmRequest request) {
         syncService.saveOrUpdateFcmToken(request);
         // TODO: Exception handling
         return Response.ofSuccess("Created/Updated for device", request.getDeviceId());
     }
 
-    @GetMapping("/{deviceId}")
-    public Response<String> getFcmToken(@PathVariable String deviceId) {
-        String fcmToken = syncService.getFcmToken(deviceId);
-        // TODO: Exception handling
-        return Response.ofSuccess("fcm token 획득", fcmToken);
-    }
+//    @GetMapping("/{deviceId}")
+//    public Response<String> getFcmToken(@PathVariable String deviceId) {
+//        String fcmToken = syncService.getFcmToken(deviceId);
+//        // TODO: Exception handling
+//        return Response.ofSuccess("fcm token 획득", fcmToken);
+//    }
 }


### PR DESCRIPTION
- Changed HTTP method from POST to PUT for saving or updating FCM tokens to follow RESTful principles (멱등성 고려)
- Commented out the GET /fcm-token/{deviceId} endpoint