### PR TITLE
fix: return correct HTTP status in Unifest exception handler

### DIFF
--- a/src/main/java/UniFest/global/common/exception/ExceptionController.java
+++ b/src/main/java/UniFest/global/common/exception/ExceptionController.java
@@ -24,7 +24,7 @@ public class ExceptionController {
     @ExceptionHandler(UnifestCustomException.class)
     public ResponseEntity<ErrorResponse> handleUnifestException(UnifestCustomException e) {
         log.warn("Unifest Exception {} {} {}\n", e.getHttpStatus(), e.getMessage(), e.getClass().getSimpleName());
-        return ResponseEntity.badRequest().body(new ErrorResponse(e.getCode(),e.getMessage()));
+        return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getCode(),e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)


### PR DESCRIPTION
Exception Handler에서 전역적으로 모든 커스텀 예외 응답을 400으로 덮고 있었음