### PR TITLE
hotfix: DTO 수정

### DIFF
--- a/src/main/java/UniFest/domain/festival/dto/request/PostFestivalRequest.java
+++ b/src/main/java/UniFest/domain/festival/dto/request/PostFestivalRequest.java
@@ -6,11 +6,11 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class PostFestivalRequest {
 


### PR DESCRIPTION
-어노테이션 수정

-참고
@Data = @Getter + @Setter + @ToString + @EqualsAndHashCode + @requiredArgsConstructor 이지만 
@AllArgsConstructor를 쓰게되면 @requiredArgsConstructor가 무시되고 기입한 어노테이션에 맞게 생성자가 생성된다고 한다. 
이로 인해 버그 발생