### PR TITLE
refactor(infra): reorganize custom error codes by category (Auth: 10x…

### DIFF
--- a/src/main/java/UniFest/global/infra/fcm/exception/FcmFailException.java
+++ b/src/main/java/UniFest/global/infra/fcm/exception/FcmFailException.java
@@ -4,6 +4,6 @@ import UniFest.global.common.exception.UnifestCustomException;
 import org.springframework.http.HttpStatus;
 
 public class FcmFailException extends UnifestCustomException {
-    public FcmFailException() { super(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 처리에 실패했습니다.", 1002); }
-    public FcmFailException(String errorMsg) { super(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 처리에 실패했습니다." + errorMsg, 1002); }
+    public FcmFailException() { super(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 처리에 실패했습니다.", 1101); }
+    public FcmFailException(String errorMsg) { super(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 처리에 실패했습니다." + errorMsg, 1101); }
 }

--- a/src/main/java/UniFest/global/infra/fcm/exception/FcmTokenNotFoundException.java
+++ b/src/main/java/UniFest/global/infra/fcm/exception/FcmTokenNotFoundException.java
@@ -4,5 +4,5 @@ import UniFest.global.common.exception.UnifestCustomException;
 import org.springframework.http.HttpStatus;
 
 public class FcmTokenNotFoundException extends UnifestCustomException {
-    public FcmTokenNotFoundException() { super(HttpStatus.NOT_FOUND, "등록된 FCM Token이 없습니다.", 1101); }
+    public FcmTokenNotFoundException() { super(HttpStatus.NOT_FOUND, "등록된 FCM 토큰이 없습니다.", 1102); }
 }

--- a/src/main/java/UniFest/global/infra/fcm/exception/InvalidFcmTokenException.java
+++ b/src/main/java/UniFest/global/infra/fcm/exception/InvalidFcmTokenException.java
@@ -1,0 +1,8 @@
+package UniFest.global.infra.fcm.exception;
+
+import UniFest.global.common.exception.UnifestCustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidFcmTokenException extends UnifestCustomException {
+    public InvalidFcmTokenException() { super(HttpStatus.BAD_REQUEST, "유효하지 않은 FCM 토큰입니다.", 1103); }
+}

--- a/src/main/java/UniFest/global/infra/fileupload/exception/ImageConvertingFailedException.java
+++ b/src/main/java/UniFest/global/infra/fileupload/exception/ImageConvertingFailedException.java
@@ -7,6 +7,6 @@ public class ImageConvertingFailedException extends UnifestCustomException {
 
     public ImageConvertingFailedException()
     {
-        super(HttpStatus.EXPECTATION_FAILED, "이미지 업로드를 위한 File 컨버팅 작업에 실패했습니다.", 1003);
+        super(HttpStatus.EXPECTATION_FAILED, "이미지 업로드를 위한 File 컨버팅 작업에 실패했습니다.", 1201);
     }
 }

--- a/src/main/java/UniFest/global/infra/fileupload/exception/UploadSizeExceedException.java
+++ b/src/main/java/UniFest/global/infra/fileupload/exception/UploadSizeExceedException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class UploadSizeExceedException extends UnifestCustomException {
 
     public UploadSizeExceedException() {
-        super(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 이미지 용량을 초과하였습니다.", 1004);
+        super(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 이미지 용량을 초과하였습니다.", 1202);
     }
 }


### PR DESCRIPTION
…x, Fcm: 11xx, FileUpload: 12xx)

Refactored existing error codes under Infra to follow a structured format:
- Auth errors → 10xx
- Fcm errors → 11xx
- FileUpload errors → 12xx

This change enables easier management and extension, such as adding new Fcm errors without overlap.