### PR TITLE
fix: 스탬프 드롭다운용 API 프로퍼티 수정, 스탬프 기본사진 설정

### DIFF
--- a/src/main/java/UniFest/domain/stamp/dto/response/StampEnabledFestivalResponse.java
+++ b/src/main/java/UniFest/domain/stamp/dto/response/StampEnabledFestivalResponse.java
@@ -1,6 +1,5 @@
 package UniFest.domain.stamp.dto.response;
 
-import UniFest.domain.festival.entity.Festival;
 import UniFest.domain.stamp.entity.StampInfo;
 import lombok.Builder;
 import lombok.Data;
@@ -9,16 +8,16 @@ import lombok.Data;
 public class StampEnabledFestivalResponse {
     private Long festivalId;
 
-    private String name;
+    private String schoolName;
 
     private String defaultImgUrl;
 
     private String usedImgUrl;
 
     @Builder
-    public StampEnabledFestivalResponse(StampInfo stampInfo) {
+    public StampEnabledFestivalResponse(StampInfo stampInfo, String schoolName) {
         this.festivalId = stampInfo.getFestival().getId();
-        this.name = stampInfo.getFestival().getName();
+        this.schoolName = schoolName;
         this.defaultImgUrl = stampInfo.getDefaultImgUrl();
         this.usedImgUrl = stampInfo.getUsedImgUrl();
     }

--- a/src/main/java/UniFest/domain/stamp/service/StampService.java
+++ b/src/main/java/UniFest/domain/stamp/service/StampService.java
@@ -103,8 +103,7 @@ public class StampService {
                 .toList();
 
         List<StampEnabledFestivalResponse> dtoFestivalList = filteredFestival.stream()
-                .map(Festival::getStampInfo)
-                .map(StampEnabledFestivalResponse::new)
+                .map(f -> new StampEnabledFestivalResponse(f.getStampInfo(), f.getSchool().getName()))
                 .toList();
 
         return dtoFestivalList;
@@ -119,9 +118,18 @@ public class StampService {
         if(festival.getStampInfo() != null){
             throw new StampInfoAlreadyAdded();
         }
+
+        //기본 unifest 이미지입니다
         StampInfo stampInfo = new StampInfo(festival
-                , stampInfoCreateRequest.getDefaultImgUrl()
-                , stampInfoCreateRequest.getUsedImgUrl());
+                , Optional.ofNullable(stampInfoCreateRequest.getDefaultImgUrl())
+                .orElseGet(() -> {
+                    return "https://unifest-prod-bucket.s3.ap-northeast-2.amazonaws.com/31a66ead-3e8c-482d-aa66-74a8289fc5c6.png";
+                })
+                , Optional.ofNullable(stampInfoCreateRequest.getUsedImgUrl())
+                .orElseGet(() -> {
+                    return "https://unifest-prod-bucket.s3.ap-northeast-2.amazonaws.com/ac843c7a-f5d7-41d4-99ec-b810fe94b15f.png";
+                })
+        );
         stampInfoRepository.save(stampInfo);
         festival.setStampInfo(stampInfo);
 


### PR DESCRIPTION
StampEnabledFestivalResponse
- Festival name 대신 School name 으로 변경

StampService
- 변경된 Dto에 맞춰 로직변경
- 스탬프 info 생성시 이미지 프로퍼티가 null이면, 기본이미지로 대체