### PR TITLE
feat(security): CORS 도메인에 WEB_DEP, 새 도메인, PREVIEW 도메인 추가

### DIFF
--- a/src/main/java/UniFest/global/infra/security/config/SecurityConfig.java
+++ b/src/main/java/UniFest/global/infra/security/config/SecurityConfig.java
@@ -31,10 +31,12 @@ import java.util.List;
 @RequiredArgsConstructor
 //springsecurity 최신버전 (6.x)이상부터는 메서드체이닝을 지양하고 람다식을 통해 함수형으로 설계
 public class SecurityConfig{
-    private static final String USER_WEB = "https://unifest.netlify.app";
+    private static final String USER_WEB_DEPRECATED = "https://unifest.netlify.app";
     private static final String USER_APP = "https://www.unifest.app";
     private static final String ADMIN_WEB = "https://project-unifest.github.io";
     private static final String LOCALHOST = "http://localhost:3000";
+    private static final String USER_WEB = "https://unifest-web-245.pages.dev/";
+    private static final String WEB_PREVIEW = "https://%2A.unifest-web-245.pages.dev/";
 
     private final AuthenticationConfiguration authenticationConfiguration;
 
@@ -49,7 +51,7 @@ public class SecurityConfig{
                     @Override
                     public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
                         CorsConfiguration configuration = new CorsConfiguration();
-                        configuration.setAllowedOrigins(List.of(LOCALHOST,USER_WEB,USER_APP,ADMIN_WEB));
+                        configuration.setAllowedOrigins(List.of(LOCALHOST,USER_WEB,USER_APP,ADMIN_WEB, USER_WEB_DEPRECATED, WEB_PREVIEW));
                         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"));
                         configuration.setAllowCredentials(true);
                         configuration.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
- CORS 허용 도메인에 WEB_DEP(https://unifest.netlify.app), 새 웹 도메인(https://unifest-web-245.pages.dev/), PREVIEW 도메인(https://*.unifest-web-245.pages.dev/) 추가
- 사용자/관리자 웹, 앱, 로컬호스트 등 기존 도메인도 유지