### PR TITLE
feat(fcm): add setSound() to centralize notification sound settings

### DIFF
--- a/src/main/java/UniFest/global/infra/fcm/FcmUtils.java
+++ b/src/main/java/UniFest/global/infra/fcm/FcmUtils.java
@@ -51,6 +51,30 @@ public final class FcmUtils {
         send(Message.builder().setTopic(topic), userNoti);
     }
 
+    private static void setSound(Message.Builder messageBuilder) {
+        // for iOS
+        Aps aps = Aps.builder()
+                .setSound("default")
+                .build();
+
+        ApnsConfig apnsConfig = ApnsConfig.builder()
+                .setAps(aps)
+                .build();
+
+        // for Android
+        AndroidNotification androidNoti = AndroidNotification.builder()
+                .setSound("default")
+                .setDefaultVibrateTimings(true)
+                .build();
+
+        AndroidConfig androidConfig = AndroidConfig.builder()
+                .setNotification(androidNoti)
+                .build();
+
+        messageBuilder.setApnsConfig(apnsConfig)
+                .setAndroidConfig(androidConfig);
+    }
+
     private static void send(Message.Builder messageBuilder, UserNoti userNoti) throws FcmFailException {
         Notification notification = Notification.builder()
                 .setTitle(userNoti.getTitle())
@@ -58,6 +82,7 @@ public final class FcmUtils {
                 .build();
 
         messageBuilder.setNotification(notification);
+        setSound(messageBuilder);
 
         Map<String, String> meta = userNoti.getMeta();
         if (meta != null && !meta.isEmpty()) {


### PR DESCRIPTION
- 분리된 setSound() 메서드를 통해 iOS(APNs)와 Android 알림 소리 설정을 통합 관리
- Notification 빌더에 sound 옵션을 일관되게 적용하여 유지보수성 향상
- 기본 사운드 "default"로 설정하여 푸시 알림 시 소리 재생 보장