### PR TITLE
hotfix : 웨이팅 호출하기 전에 유저가 취소한 경우 404 리턴

### DIFF
--- a/src/main/java/UniFest/domain/waiting/service/WaitingService.java
+++ b/src/main/java/UniFest/domain/waiting/service/WaitingService.java
@@ -1,7 +1,6 @@
 package UniFest.domain.waiting.service;
 
 import UniFest.domain.booth.entity.Booth;
-import UniFest.domain.booth.exception.BoothNotFoundException;
 import UniFest.domain.booth.repository.BoothRepository;
 import UniFest.domain.waiting.dto.request.PostWaitingRequest;
 import UniFest.domain.waiting.dto.response.WaitingInfo;

--- a/src/main/java/UniFest/domain/waiting/service/WaitingService.java
+++ b/src/main/java/UniFest/domain/waiting/service/WaitingService.java
@@ -1,14 +1,17 @@
 package UniFest.domain.waiting.service;
 
 import UniFest.domain.booth.entity.Booth;
+import UniFest.domain.booth.exception.BoothNotFoundException;
 import UniFest.domain.booth.repository.BoothRepository;
 import UniFest.domain.waiting.dto.request.PostWaitingRequest;
 import UniFest.domain.waiting.dto.response.WaitingInfo;
 import UniFest.domain.waiting.entity.Waiting;
 import UniFest.domain.waiting.repository.WaitingRepository;
+import UniFest.global.common.exception.UnifestCustomException;
 import UniFest.global.infra.fcm.UserNoti;
 import UniFest.global.infra.fcm.service.FcmService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -138,6 +141,9 @@ public class WaitingService {
     @Transactional
     public WaitingInfo callWaiting(Long id) {
         WaitingInfo info = setWaitingById(id, "CALLED");
+        if(info == null){
+            throw new UnifestCustomException(HttpStatus.NOT_FOUND, "웨이팅을 찾을 수 없습니다. 유저가 취소한 웨이팅일 수 있습니다.", 8000);
+        }
         Waiting w = waitingRepository.findWaitingByDeviceIdAndId(info.getDeviceId(), info.getWaitingId());
 
         UserNoti userNoti = UserNoti.builder()


### PR DESCRIPTION
### AS-IS
현재 웨이팅을 호출하기 전에 유저가 취소하는 경우 500 INTERNAL SERVER ERROR (NullpointException) 이 발생한다
<img width="2559" height="1422" alt="image" src="https://github.com/user-attachments/assets/e16eb6fa-1ec3-4983-9252-ad92bcc05bd1" />

### TO-BE
프론트에서 404는 처리를해놨기 때문에 404 에러코드로 처리한다.