### PR TITLE
feat : 이미지 경량화 코드 작성

### DIFF
--- a/src/main/java/UniFest/domain/booth/entity/Booth.java
+++ b/src/main/java/UniFest/domain/booth/entity/Booth.java
@@ -16,6 +16,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,6 +66,13 @@ public class Booth extends BaseEntity {
 
     @Column(name = "enabled")
     private boolean enabled = true;
+
+    @Column(name = "deleted", nullable = false)
+    @ColumnDefault("false")
+    private boolean deleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> lmgList = new ArrayList<>();

--- a/src/main/java/UniFest/domain/booth/repository/BoothRepository.java
+++ b/src/main/java/UniFest/domain/booth/repository/BoothRepository.java
@@ -34,4 +34,10 @@ public interface BoothRepository extends JpaRepository<Booth,Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Booth b SET b.enabled = :isEnabled WHERE NOT EXISTS (SELECT s FROM b.scheduleList s WHERE FUNCTION('date', s.openDate) = :today)")
     void updateBoothDisabled(LocalDate today, boolean isEnabled);
+
+    List<Booth> findByThumbnail(String thumbnail);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Booth b SET b.thumbnail = :newThumbnail WHERE b.thumbnail = :oldThumbnail")
+    void updateThumbnail(@Param("oldThumbnail") String oldThumbnail, @Param("newThumbnail") String newThumbnail);
 }

--- a/src/main/java/UniFest/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/UniFest/domain/festival/repository/FestivalRepository.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -46,4 +47,11 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
             + " where :date between f.beginDate and f.endDate "
             + " order by s.name")
     List<TodayFestivalInfo> findFestivalByDate(@Param("date") LocalDate date);
+
+    List<Festival> findByThumbnail(String thumbnail);
+    
+    @Modifying
+    @Query("UPDATE Festival f SET f.thumbnail = :newThumbnail WHERE f.thumbnail = :oldThumbnail")
+    void updateThumbnail(@Param("oldThumbnail") String oldThumbnail, @Param("newThumbnail") String newThumbnail);
+
 }

--- a/src/main/java/UniFest/domain/home/repository/HomeCardRepository.java
+++ b/src/main/java/UniFest/domain/home/repository/HomeCardRepository.java
@@ -2,9 +2,23 @@ package UniFest.domain.home.repository;
 
 import UniFest.domain.home.entity.HomeCard;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface HomeCardRepository extends JpaRepository<HomeCard, Long> {
     List<HomeCard> findAll();
+    
+    List<HomeCard> findByThumbnailImgUrl(String thumbnailImgUrl);
+    List<HomeCard> findByDetailImgUrl(String detailImgUrl);
+    
+    @Modifying
+    @Query("UPDATE HomeCard h SET h.thumbnailImgUrl = :newThumbnailImgUrl WHERE h.thumbnailImgUrl = :oldThumbnailImgUrl")
+    void updateThumbnailImgUrl(@Param("oldThumbnailImgUrl") String oldThumbnailImgUrl, @Param("newThumbnailImgUrl") String newThumbnailImgUrl);
+    
+    @Modifying
+    @Query("UPDATE HomeCard h SET h.detailImgUrl = :newDetailImgUrl WHERE h.detailImgUrl = :oldDetailImgUrl")
+    void updateDetailImgUrl(@Param("oldDetailImgUrl") String oldDetailImgUrl, @Param("newDetailImgUrl") String newDetailImgUrl);
 }

--- a/src/main/java/UniFest/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/UniFest/domain/menu/repository/MenuRepository.java
@@ -2,8 +2,19 @@ package UniFest.domain.menu.repository;
 
 import UniFest.domain.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface MenuRepository extends JpaRepository<Menu,Long> {
+    
+    List<Menu> findByImgUrl(String imgUrl);
+    
+    @Modifying
+    @Query("UPDATE Menu m SET m.imgUrl = :newImgUrl WHERE m.imgUrl = :oldImgUrl")
+    void updateImgUrl(@Param("oldImgUrl") String oldImgUrl, @Param("newImgUrl") String newImgUrl);
 }

--- a/src/main/java/UniFest/domain/school/repository/SchoolRepository.java
+++ b/src/main/java/UniFest/domain/school/repository/SchoolRepository.java
@@ -2,7 +2,17 @@ package UniFest.domain.school.repository;
 
 import UniFest.domain.school.entity.School;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface SchoolRepository extends JpaRepository<School, Long> {
 
+    List<School> findByThumbnail(String thumbnail);
+    
+    @Modifying
+    @Query("UPDATE School s SET s.thumbnail = :newThumbnail WHERE s.thumbnail = :oldThumbnail")
+    void updateThumbnail(@Param("oldThumbnail") String oldThumbnail, @Param("newThumbnail") String newThumbnail);
 }

--- a/src/main/java/UniFest/domain/star/dto/request/PostEnrollRequest.java
+++ b/src/main/java/UniFest/domain/star/dto/request/PostEnrollRequest.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostEnrollRequest {
-
     @NotNull(message = "festivalId는 null이면 안됩니다.")
     @Schema(description = "페스티벌 Id", nullable = false)
     private Long festivalId;

--- a/src/main/java/UniFest/domain/star/repository/StarRepository.java
+++ b/src/main/java/UniFest/domain/star/repository/StarRepository.java
@@ -4,6 +4,7 @@ import UniFest.domain.star.entity.Star;
 import UniFest.domain.star.dto.response.StarInfo;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,10 @@ public interface StarRepository extends JpaRepository<Star, Long> {
     @Query("SELECT new UniFest.domain.star.dto.response.StarInfo(s.id, s.name, s.img) " +
             "FROM Star s WHERE LOWER(s.name) LIKE LOWER(CONCAT('%', :name, '%'))")
     List<StarInfo> findByNameContainingIgnoreCase(@Param("name") String name);
+
+    List<Star> findByImg(String img);
+    
+    @Modifying
+    @Query("UPDATE Star s SET s.img = :newImg WHERE s.img = :oldImg")
+    void updateImg(@Param("oldImg") String oldImg, @Param("newImg") String newImg);
 }

--- a/src/main/java/UniFest/global/infra/fileupload/controller/FileController.java
+++ b/src/main/java/UniFest/global/infra/fileupload/controller/FileController.java
@@ -1,14 +1,17 @@
 package UniFest.global.infra.fileupload.controller;
 
+import UniFest.domain.menu.dto.request.MenuCreateRequest;
 import UniFest.global.common.response.Response;
 import UniFest.global.infra.fileupload.dto.response.FileResponse;
 import UniFest.global.infra.fileupload.service.FileService;
+import UniFest.global.infra.security.userdetails.MemberDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -25,3 +28,4 @@ public class FileController {
         return Response.ofSuccess("OK", fileResponse);
     }
 }
+

--- a/src/main/java/UniFest/global/infra/imgopti/controller/ImgoptiController.java
+++ b/src/main/java/UniFest/global/infra/imgopti/controller/ImgoptiController.java
@@ -1,0 +1,23 @@
+package UniFest.global.infra.imgopti.controller;
+
+import UniFest.global.common.response.Response;
+import UniFest.global.infra.imgopti.dto.ImgoptiRequest;
+import UniFest.global.infra.imgopti.service.ImgoptiService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/image/opti")
+public class ImgoptiController {
+    private final ImgoptiService imgoptiService;
+    @PostMapping
+    public Response<Void> completeOpti(@Valid @RequestBody ImgoptiRequest imgoptiRequest){
+        imgoptiService.optimizeImage(imgoptiRequest.getPreImgUrl(), imgoptiRequest.getPostImgUrl());
+        return Response.ofSuccess("OK");
+    }
+}

--- a/src/main/java/UniFest/global/infra/imgopti/dto/ImgoptiRequest.java
+++ b/src/main/java/UniFest/global/infra/imgopti/dto/ImgoptiRequest.java
@@ -1,0 +1,20 @@
+package UniFest.global.infra.imgopti.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ImgoptiRequest {
+    @NotNull(message="preImgURL은 null이면 안됩니다.")
+    @Schema(nullable = false)
+    private String preImgUrl;
+
+    @NotNull(message="postImgURL은 null이면 안됩니다.")
+    @Schema(nullable = false)
+    private String postImgUrl;
+}

--- a/src/main/java/UniFest/global/infra/imgopti/service/ImgoptiService.java
+++ b/src/main/java/UniFest/global/infra/imgopti/service/ImgoptiService.java
@@ -1,0 +1,77 @@
+package UniFest.global.infra.imgopti.service;
+
+import UniFest.domain.booth.repository.BoothRepository;
+import UniFest.domain.festival.repository.FestivalRepository;
+import UniFest.domain.home.repository.HomeCardRepository;
+import UniFest.domain.menu.repository.MenuRepository;
+import UniFest.domain.school.repository.SchoolRepository;
+import UniFest.domain.star.repository.StarRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ImgoptiService {
+    
+    private final BoothRepository boothRepository;
+    private final FestivalRepository festivalRepository;
+    private final HomeCardRepository homeCardRepository;
+    private final MenuRepository menuRepository;
+    private final SchoolRepository schoolRepository;
+    private final StarRepository starRepository;
+
+    public void optimizeImage(String preImgUrl, String postImgUrl){
+        // Booth 관련 이미지 업데이트
+        updateBoothImages(preImgUrl, postImgUrl);
+        
+        // Festival 관련 이미지 업데이트
+        updateFestivalImages(preImgUrl, postImgUrl);
+        
+        // HomeCard 관련 이미지 업데이트
+        updateHomeCardImages(preImgUrl, postImgUrl);
+        
+        // Menu 관련 이미지 업데이트
+        updateMenuImages(preImgUrl, postImgUrl);
+        
+        // School 관련 이미지 업데이트
+        updateSchoolImages(preImgUrl, postImgUrl);
+        
+        // Star 관련 이미지 업데이트
+        updateStarImages(preImgUrl, postImgUrl);
+    }
+    
+    private void updateBoothImages(String preImgUrl, String postImgUrl) {
+        // Booth의 thumbnail 업데이트
+        boothRepository.updateThumbnail(preImgUrl, postImgUrl);
+    }
+    
+    private void updateFestivalImages(String preImgUrl, String postImgUrl) {
+        // Festival의 thumbnail 업데이트
+        festivalRepository.updateThumbnail(preImgUrl, postImgUrl);
+    }
+    
+    private void updateHomeCardImages(String preImgUrl, String postImgUrl) {
+        // HomeCard의 thumbnailImgUrl 업데이트
+        homeCardRepository.updateThumbnailImgUrl(preImgUrl, postImgUrl);
+        
+        // HomeCard의 detailImgUrl 업데이트
+        homeCardRepository.updateDetailImgUrl(preImgUrl, postImgUrl);
+    }
+    
+    private void updateMenuImages(String preImgUrl, String postImgUrl) {
+        // Menu의 imgUrl 업데이트
+        menuRepository.updateImgUrl(preImgUrl, postImgUrl);
+    }
+    
+    private void updateSchoolImages(String preImgUrl, String postImgUrl) {
+        // School의 thumbnail 업데이트
+        schoolRepository.updateThumbnail(preImgUrl, postImgUrl);
+    }
+    
+    private void updateStarImages(String preImgUrl, String postImgUrl) {
+        // Star의 img 업데이트
+        starRepository.updateImg(preImgUrl, postImgUrl);
+    }
+}


### PR DESCRIPTION
### 개요
- 이미지 경량화를 진행할 시, 이미지 파일 경량화과 완료된 시점과 그 파일명을 서버와 DB에 안내할 필요가 있다
- 따라서 swagger 상에는 보이지 않는 API를 하나 생성, 이를 이용해 AWS Lambda와 소통한다.

### 비고
- 현재 파일명을 통해 이미지 URL을 사용하는 모든 DB에 쿼리를 진행한다. 이로 인한 성능 문제가 예상되나, 이미지 업로드는 자주 있는 작업이 아니므로 당장은 기술부채로 넘겨둔다.